### PR TITLE
Allow option to explicitly pass a mongoose instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,24 @@
 'use strict';
 
 var shimmer = require('shimmer');
-var mongoose = require('mongoose');
 
-module.exports = function patchMPromise(ns) {
 
+module.exports = function patchMPromise(ns, _mongoose) {
+
+  //If there are multiple mongoose versions in the dependency tree, then the `require('mongodb')` could contain differnent objects
+  // This allows users to explicitly pass a `mongoose` object to bind. 
+  var mongoose = _mongoose || require('mongoose');
   if (typeof ns.bind !== 'function') {
     throw new TypeError("must include namespace to patch Mongoose against");
   }
-  
+
   shimmer.wrap(mongoose.Mongoose.prototype.Promise.prototype, 'on', function (original) {
     return function(event, callback) {
       callback = ns.bind(callback);
       return original.call(this, event, callback);
     };
   });
-  
+
   shimmer.wrap(mongoose.Mongoose.prototype.Query.prototype, 'exec', function (original) {
     return function(op, callback) {
       if (typeof op == 'function') op = ns.bind(op);
@@ -31,4 +34,3 @@ module.exports = function patchMPromise(ns) {
     };
   });
 };
-

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "shimmer": "^1"
   },
   "peerDependencies": {
-    "mongoose": "3.8.*"
+    "mongoose": ">= 3.8.16 < 5"
   },
   "devDependencies": {
     "tap": "~1.3.2",


### PR DESCRIPTION
# Motivation

There are dependencies on multiple versions of mongoose in fh-mbaas.
- fh-mbaas has version 4.5.0 in the shrinkwrap
- fh-mbaas-middleware has version 4.5.1 in the shrinkwrap

This causes a problem, as if there is only one version of cls-mongoose in the shrinkwrap, then it will cache the version of mongoose. 

Therefore it can bind different objects.
# Solution

Allow passing an optional explicit mongoose instance to bind.
